### PR TITLE
Workaround for EXTJS-15054 in ExtJS 4.2.3

### DIFF
--- a/ux/panel/PDF.js
+++ b/ux/panel/PDF.js
@@ -260,8 +260,12 @@ Ext.define('Ext.ux.panel.PDF',{
         me.items = userItems;
 
         me.callParent(arguments);
-
-        me.on('afterrender', function(){
+	
+	// An exception was thrown in afterrender handler when upgrading to 2.4.3. It seems that there is
+        // a bug in that version, however using a proposed workaround from Sencha forum solved the problem: 
+	// (http://www.sencha.com/forum/showthread.php?291412-Error-after-upgrade-to-ExtJS-4.2.3&p=1064679)
+	// 'afterrenderer' --> 'boxready'
+        me.on('boxready', function(){ 
             me.loader = new Ext.LoadMask(me.child('#pdfPageContainer'),{
                 msg: me.loadingMessage
             });


### PR DESCRIPTION
After upgrading to ExtJS 4.2.3 an exception was thrown in PDF.js:

  Uncaught TypeError: Cannot read property 'isItemBoxParent' of undefined

Following the hints on the forum, moving LoadMask from afterrrender to boxready solved the problem.

http://www.sencha.com/forum/showthread.php?291412-Error-after-upgrade-to-ExtJS-4.2.3&p=1064679
